### PR TITLE
Fixed issue with tab not changing title when sheet title changed

### DIFF
--- a/static/pysheets.py
+++ b/static/pysheets.py
@@ -1606,6 +1606,7 @@ def setup_login():
 def set_name(event):
     state.doc.edits[constants.DATA_KEY_NAME] = state.doc.name = ltk.find("#title").val()
     state.doc.last_edit = window.time()
+    window.document.title = state.doc.name
 
 
 ltk.find("#title").on("change", proxy(set_name))


### PR DESCRIPTION
Fixed minor bug where title of tab was not sync'd with title of the sheet when changing the title